### PR TITLE
Migrated gulp file from Gulp 3.0 to Gulp 4.0; fixed breaking changes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,24 +6,26 @@ var minify = require("gulp-minify");
 var browserSync = require("browser-sync").create();
 var postcss = require("gulp-postcss");
 var autoprefixer = require("autoprefixer");
+var reload = browserSync.reload;
 
 gulp.task("watch", function() {
-  gulp.watch(
-    ["./public/sass/*/*.sass", "./public/sass/*.sass"],
-    gulp.series("sass", "minify-css", browserSync.reload)
-  );
-  gulp.watch(
-    [
-      "./public/javascripts/index.js",
-      "./public/javascripts/index2.js",
-      "./public/javascripts/index3.js"
-    ],
-    gulp.series("minify-js", browserSync.reload)
-  );
-  gulp.watch(
-    ["./views/*.pug", "./views/**/*.pug"],
-    gulp.series(browserSync.reload)
-  );
+  gulp
+    .watch(
+      ["./public/sass/*/*.sass", "./public/sass/*.sass"],
+      gulp.series("sass", "minify-css")
+    )
+    .on("change", reload);
+  gulp
+    .watch(
+      [
+        "./public/javascripts/index.js",
+        "./public/javascripts/index2.js",
+        "./public/javascripts/index3.js"
+      ],
+      gulp.series("minify-js")
+    )
+    .on("change", reload);
+  gulp.watch(["./views/*.pug", "./views/**/*.pug"]).on("change", reload);
 });
 
 gulp.task("autoprefixer", function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,13 +7,10 @@ var browserSync = require("browser-sync").create();
 var postcss = require("gulp-postcss");
 var autoprefixer = require("autoprefixer");
 
-gulp.task("default", ["watch", "browser-sync-proxy"]);
-
 gulp.task("watch", function() {
   gulp.watch(
     ["./public/sass/*/*.sass", "./public/sass/*.sass"],
-    ["sass", "minify-css"],
-    browserSync.reload
+    gulp.series("sass", "minify-css", browserSync.reload)
   );
   gulp.watch(
     [
@@ -21,10 +18,12 @@ gulp.task("watch", function() {
       "./public/javascripts/index2.js",
       "./public/javascripts/index3.js"
     ],
-    ["minify-js"],
-    browserSync.reload
+    gulp.series("minify-js", browserSync.reload)
   );
-  gulp.watch(["./views/*.pug", "./views/**/*.pug"], browserSync.reload);
+  gulp.watch(
+    ["./views/*.pug", "./views/**/*.pug"],
+    gulp.series(browserSync.reload)
+  );
 });
 
 gulp.task("autoprefixer", function() {
@@ -34,7 +33,7 @@ gulp.task("autoprefixer", function() {
     .pipe(gulp.dest("./public/stylesheets/"));
 });
 
-gulp.task("minify-css", ["autoprefixer"], function() {
+gulp.task("minify-css", gulp.series("autoprefixer"), function() {
   gulp
     .src("./public/stylesheets/main.css")
     .pipe(cleanCSS({ compatibility: "ie8", keepBreaks: false }))
@@ -78,3 +77,5 @@ gulp.task("browser-sync", function() {
     }
   });
 });
+
+gulp.task("default", gulp.series(gulp.parallel("watch", "browser-sync-proxy")));


### PR DESCRIPTION
Closes issue #54.

The only breaking changes from Gulp 3.0 -> Gulp 4.0 involves how tasks are specified in order. 

Gulp 4 now uses gulp.series() to run tasks in order, or gulp.parallel() to run tasks in parallel. For the sake of convenience I left the Gulp 3 method of registering tasks as-is (using gulp.task() as opposed to exporting individual functions) 
```
//Gulp 3
gulp.watch("./public/sass/*/*.sass", ["sass", "minify-css"])
//Gulp 4
gulp.watch("./public/sass/*/*.sass", gulp.series("sass", "minify-css"));

```
I did not test with the backend portion of the application but the default task (which depends on the other tasks to function) works and the browserSync sends out a reload message when any watched file is altered. 

![mangadbGulp4](https://user-images.githubusercontent.com/7098115/97823249-5dcf6380-1c86-11eb-916b-25f82035e114.png)
